### PR TITLE
Update Dockerfile to work with ShiftaDeband's fork (feature/httpGet branch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM ruby:2.3
-COPY . /build
-RUN cd build && \
-    bundle install
-ENTRYPOINT [ "/usr/local/bundle/bin/wayback_machine_downloader" ]
+FROM ruby:3.3
+COPY . /run
+ENTRYPOINT [ "/run/bin/wayback_machine_downloader" ]


### PR DESCRIPTION
This Dockerfile builds an image that works with ShiftaDeband's fork (feature/httpGet branch)